### PR TITLE
[Feature] Adds a rss notification feed for recently updated stories

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -25,5 +25,4 @@ urlpatterns = [
     url(r'^api/assignments/',
         include('assignments.urls', namespace='assignments')),
     url(r'^api/stories/', include('stories.urls', namespace='stories')),
-
 ]

--- a/stories/feeds.py
+++ b/stories/feeds.py
@@ -1,0 +1,26 @@
+from django.db import models
+from django.contrib.syndication.views import Feed
+from django.urls import reverse
+from stories.models import Story
+from api.urls import *
+
+
+class LatestEntryFeed(Feed):
+    """
+    This class creates a view for viewing an RSS Feed of the latest stories.    
+    """
+    title = "Stories feed from Citizen Reporter"
+    link = "/feeds/"
+    description = "This is a feed showing all the posted stories from Citizen Reporter"
+
+    def items(self):
+        return Story.objects.order_by('created')[:5]
+
+    def item_title(self, item):
+        return item.title
+
+    def item_description(self, item):
+        return item.summary
+
+    def item_link(self, item):
+        return item.get_absolute_url()

--- a/stories/feeds.py
+++ b/stories/feeds.py
@@ -1,20 +1,21 @@
-from django.db import models
 from django.contrib.syndication.views import Feed
+from django.db import models
 from django.urls import reverse
-from stories.models import Story
+
 from api.urls import *
+from stories.models import Story
 
 
 class LatestEntryFeed(Feed):
     """
-    This class creates a view for viewing an RSS Feed of the latest stories.    
+    This class creates a view for viewing an RSS Feed of the latest stories.
     """
     title = "Stories feed from Citizen Reporter"
     link = "/feeds/"
     description = "This is a feed showing all the posted stories from Citizen Reporter"
 
     def items(self):
-        return Story.objects.order_by('created')[:5]
+        return Story.objects.order_by('-created')[:5]
 
     def item_title(self, item):
         return item.title

--- a/stories/models.py
+++ b/stories/models.py
@@ -15,7 +15,7 @@ class Story(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     local_id = models.IntegerField(default=0)
     assignmentId = models.IntegerField(default=0)
-    title = models.CharField(null=False, max_length=250)
+    title = models.CharField(null=False, max_length=250, default="")
     summary = models.TextField()
     when = models.CharField(max_length=20, default="")
     where = models.CharField(max_length=200, default='Unkown')
@@ -26,8 +26,12 @@ class Story(models.Model):
     updated = models.CharField(max_length=30, default="unknown")
     local_media_paths = models.TextField(max_length=5000, default="")
 
+    def get_absolute_url(self):
+        return "/stories/{}".format(self.local_id)
+
     class Meta:
         ordering = ('created',)
+    
 
 
 class Media(models.Model):
@@ -38,3 +42,6 @@ class Media(models.Model):
 
     def __unicode__(self):
         return "{0}{1}".format(MEDIA_URL, self.file.url)
+
+
+

--- a/stories/models.py
+++ b/stories/models.py
@@ -31,7 +31,6 @@ class Story(models.Model):
 
     class Meta:
         ordering = ('created',)
-    
 
 
 class Media(models.Model):
@@ -42,6 +41,3 @@ class Media(models.Model):
 
     def __unicode__(self):
         return "{0}{1}".format(MEDIA_URL, self.file.url)
-
-
-

--- a/stories/urls.py
+++ b/stories/urls.py
@@ -1,9 +1,9 @@
 from django.conf import settings
 from django.conf.urls import url
 from django.conf.urls.static import static
-from rest_framework.urlpatterns import format_suffix_patterns
-from feeds import LatestEntryFeed
 
+from feeds import LatestEntryFeed
+from rest_framework.urlpatterns import format_suffix_patterns
 from stories import views
 
 urlpatterns = [

--- a/stories/urls.py
+++ b/stories/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.conf.urls import url
 from django.conf.urls.static import static
 from rest_framework.urlpatterns import format_suffix_patterns
+from feeds import LatestEntryFeed
 
 from stories import views
 
@@ -14,6 +15,7 @@ urlpatterns = [
         views.UserStoriesView.as_view(), name="user-stories"),
     url(r'^(?P<pk>[0-9]+)/$',
         views.StoriesDetailView.as_view(), name="details"),
+    url(r'^feeds/', LatestEntryFeed()),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 urlpatterns = format_suffix_patterns(urlpatterns)


### PR DESCRIPTION
## What does this PR do?

Adds an endpoint for sending rss feed notifications when a user uploads a story to Citizen Reporter

## Description of Task to be completed?

Provide an RSS feed for submitted stories. Updated every time a new story is added

## How should this be manually tested?

Ping the api endpoint @ http://api.creporter.codeforafrica.org/api/stories/feeds/

You should see an RSS feed looking like this 

![image](https://user-images.githubusercontent.com/26283552/30214407-091618cc-94b5-11e7-915c-6db8320143ad.png)


## Background information to provide

This page provides a feed of stories, however the stories themselves are not clickable.