### PR TITLE
[chore] Fixes story serializer, view and model for parse webhook

### DIFF
--- a/assignments/tests.py
+++ b/assignments/tests.py
@@ -40,7 +40,7 @@ class CRUDTestCase(APITestCase):
 
     def test_post_method_for_assignments(self):
         url = reverse('assignments:list')
-        print url
+        print(url)
         data = {'title': 'Test Works!',
                 'description': "Post method works",
                 "required_media": "Image", "deadline": "2017-09-01",

--- a/stories/models.py
+++ b/stories/models.py
@@ -14,8 +14,8 @@ class Story(models.Model):
 
     created = models.DateTimeField(auto_now_add=True)
     local_id = models.IntegerField(default=0)
-    assignmentId = models.IntegerField(default=0)
-    title = models.CharField(null=False, max_length=250)
+    assignmentId = models.CharField(max_length=250)
+    title = models.CharField(null=False, max_length=250, default="")
     summary = models.TextField()
     when = models.CharField(max_length=20, default="")
     where = models.CharField(max_length=200, default='Unkown')

--- a/stories/serializers.py
+++ b/stories/serializers.py
@@ -2,6 +2,21 @@ from rest_framework import serializers
 
 from stories.models import Media, Story
 
+class ParseStorySerializer(serializers.Serializer):
+    created = serializers.DateTimeField()
+    local_id = serializers.CharField()
+    assignmentId = serializers.CharField(max_length=200)
+    title = serializers.CharField()
+    summary = serializers.CharField()
+    when = serializers.DateTimeField()
+    where = serializers.CharField()
+    who = serializers.CharField()
+    author = serializers.CharField()
+    uploaded = serializers.BooleanField()
+    updated = serializers.DateTimeField()
+
+    def create(self, validated_data):
+         return Story(**validated_data)
 
 class StorySerializer(serializers.ModelSerializer):
     """Serializer to map the Model instance into JSON format."""

--- a/stories/serializers.py
+++ b/stories/serializers.py
@@ -14,6 +14,7 @@ class ParseStorySerializer(serializers.Serializer):
     author = serializers.CharField()
     uploaded = serializers.BooleanField()
     updated = serializers.DateTimeField()
+    local_media_paths = serializers.ListField(child=serializers.CharField())
 
     def create(self, validated_data):
          return Story(**validated_data)

--- a/stories/tests.py
+++ b/stories/tests.py
@@ -186,20 +186,17 @@ class ParseStoryTest(APITestCase):
             {
                 "__type": "File",
                 "name": "f54d6bee2fffddd5a1df2c26a8c5586a_IMG-20171003-WA0019.jpg",
-                "url": "http://creporter-server.herokuapp.com/parse/files/11235813/f54d\
-                6bee2fffddd5a1df2c26a8c5586a_IMG-20171003-WA0019.jpg"
+                "url": "http://creporter-server.herokuapp.com/parse/files/11235813/f54d6bee2fffddd5a1df2c26a8c5586a_IMG-20171003-WA0019.jpg"
             },
             {
                 "__type": "File",
                 "name": "66cb1dee3df2d7d3aff2a5cffd05f103_IMG-20171003-WA0018.jpg",
-                "url": "http://creporter-server.herokuapp.com/parse/files/11235813/66cb\
-                1dee3df2d7d3aff2a5cffd05f103_IMG-20171003-WA0018.jpg"
+                "url": "http://creporter-server.herokuapp.com/parse/files/11235813/66cb1dee3df2d7d3aff2a5cffd05f103_IMG-20171003-WA0018.jpg"
             },
             {
                 "__type": "File",
                 "name": "f8df0f1ff10c6d9c16e51ac8ac8966c6_IMG-20171003-WA0020.jpg",
-                "url": "http://creporter-server.herokuapp.com/parse/files/11235813/f8df\
-                0f1ff10c6d9c16e51ac8ac8966c6_IMG-20171003-WA0020.jpg"
+                "url": "http://creporter-server.herokuapp.com/parse/files/11235813/f8df0f1ff10c6d9c16e51ac8ac8966c6_IMG-20171003-WA0020.jpg"
             }
         ],
         "author": "QiR90vrhcR",
@@ -267,13 +264,10 @@ class ParseStoryTest(APITestCase):
         """Test whether multiple media urls will get posted to the endpoint."""
         url = reverse('stories:parse')
         response = self.client.post(url, data=self.parse_story, format='json')
-        self.assertIn("http://creporter-server.herokuapp.com/parse/files/11235813/66cb1dee3df2d7d3\
-        aff2a5cffd05f103_IMG-20171003-WA0018.jpg",
+        self.assertIn("http://creporter-server.herokuapp.com/parse/files/11235813/66cb1dee3df2d7d3aff2a5cffd05f103_IMG-20171003-WA0018.jpg",
                       response.data["local_media_paths"])
-        self.assertIn("http://creporter-server.herokuapp.com/parse/files/11235813/f8df0f1ff10c6d9c\
-        16e51ac8ac8966c6_IMG-20171003-WA0020.jpg",
+        self.assertIn("http://creporter-server.herokuapp.com/parse/files/11235813/f8df0f1ff10c6d9c16e51ac8ac8966c6_IMG-20171003-WA0020.jpg",
                       response.data["local_media_paths"])
-        self.assertIn("http://creporter-server.herokuapp.com/parse/files/11235813/f8df0f1ff10c6d9c1\
-        6e51ac8ac8966c6_IMG-20171003-WA0020.jpg",
+        self.assertIn("http://creporter-server.herokuapp.com/parse/files/11235813/f8df0f1ff10c6d9c16e51ac8ac8966c6_IMG-20171003-WA0020.jpg",
                       response.data["local_media_paths"])
         

--- a/stories/tests.py
+++ b/stories/tests.py
@@ -182,7 +182,26 @@ class ParseStoryTest(APITestCase):
         "uploaded": "true",
         "localID": "d31e17fd-a70b-4083-b04d-4c05cab266fa",
         "summary": "Yup",
-        "media": [],
+        "media": [
+            {
+                "__type": "File",
+                "name": "f54d6bee2fffddd5a1df2c26a8c5586a_IMG-20171003-WA0019.jpg",
+                "url": "http://creporter-server.herokuapp.com/parse/files/11235813/f54d\
+                6bee2fffddd5a1df2c26a8c5586a_IMG-20171003-WA0019.jpg"
+            },
+            {
+                "__type": "File",
+                "name": "66cb1dee3df2d7d3aff2a5cffd05f103_IMG-20171003-WA0018.jpg",
+                "url": "http://creporter-server.herokuapp.com/parse/files/11235813/66cb\
+                1dee3df2d7d3aff2a5cffd05f103_IMG-20171003-WA0018.jpg"
+            },
+            {
+                "__type": "File",
+                "name": "f8df0f1ff10c6d9c16e51ac8ac8966c6_IMG-20171003-WA0020.jpg",
+                "url": "http://creporter-server.herokuapp.com/parse/files/11235813/f8df\
+                0f1ff10c6d9c16e51ac8ac8966c6_IMG-20171003-WA0020.jpg"
+            }
+        ],
         "author": "QiR90vrhcR",
         "createdAt": "2017-10-03T12:14:57.511Z",
         "updatedAt": "2017-10-03T12:14:57.511Z",
@@ -235,10 +254,26 @@ class ParseStoryTest(APITestCase):
         "sessionToken": "r:bc62398c1da0ad288f55b025c51e5aeb",
         "objectId": "QiR90vrhcR"
     },
-    "installationId": "7b96b0e1-fa59-4899-a942-825a69fbea28"
-}
+            "installationId": "7b96b0e1-fa59-4899-a942-825a69fbea28"
+    }
 
     def test_post_webhook_parse(self):
+        """Tests whether the app will post parse story objects to our Django endpoint."""
         url = reverse('stories:parse')
         response = self.client.post(url, data=self.parse_story, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+   
+    def test_post_webhook_media(self):
+        """Test whether multiple media urls will get posted to the endpoint."""
+        url = reverse('stories:parse')
+        response = self.client.post(url, data=self.parse_story, format='json')
+        self.assertIn("http://creporter-server.herokuapp.com/parse/files/11235813/66cb1dee3df2d7d3\
+        aff2a5cffd05f103_IMG-20171003-WA0018.jpg",
+                      response.data["local_media_paths"])
+        self.assertIn("http://creporter-server.herokuapp.com/parse/files/11235813/f8df0f1ff10c6d9c\
+        16e51ac8ac8966c6_IMG-20171003-WA0020.jpg",
+                      response.data["local_media_paths"])
+        self.assertIn("http://creporter-server.herokuapp.com/parse/files/11235813/f8df0f1ff10c6d9c1\
+        6e51ac8ac8966c6_IMG-20171003-WA0020.jpg",
+                      response.data["local_media_paths"])
+        

--- a/stories/tests.py
+++ b/stories/tests.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import json
+
 import shutil
 
 from django.test import TestCase
@@ -165,10 +167,78 @@ class ParseStoryTest(APITestCase):
     the API after saving the Story in Parse.
     """
 
-    def setup(self):
-        self.parse_story = {}
+    def setUp(self):
+        self.parse_story = {
+    "triggerName": "afterSave",
+    "object": {
+        "when": {
+            "__type": "Date",
+            "iso": "2017-10-03T12:14:52.593Z"
+        },
+        "title": "Baga",
+        "who": "Me",
+        "location": "Andela Kenya",
+        "assignment": "5dOOMjWo2u",
+        "uploaded": "true",
+        "localID": "d31e17fd-a70b-4083-b04d-4c05cab266fa",
+        "summary": "Yup",
+        "media": [],
+        "author": "QiR90vrhcR",
+        "createdAt": "2017-10-03T12:14:57.511Z",
+        "updatedAt": "2017-10-03T12:14:57.511Z",
+        "objectId": "EDiV5IwzMc",
+        "className": "Story"
+    },
+    "master": "false",
+    "log": {
+        "appId": "11235813"
+    },
+    "headers": {
+        "host": "creporter-server.herokuapp.com",
+        "connection": "close",
+        "x-parse-session-token": "r:bc62398c1da0ad288f55b025c51e5aeb",
+        "x-parse-application-id": "11235813",
+        "x-parse-client-version": "a1.15.7",
+        "x-parse-app-build-version": "1",
+        "x-parse-app-display-version": "1.3-beta",
+        "x-parse-os-version": "6.0",
+        "user-agent": "Parse Android SDK 1.15.7 (org.codeforafrica.citizenreporterandroid/1) API Level 23",
+        "x-parse-installation-id": "7b96b0e1-fa59-4899-a942-825a69fbea28",
+        "content-type": "application/json",
+        "accept-encoding": "gzip",
+        "x-request-id": "0ed31771-b0d2-4f56-b2cf-f692b105474a",
+        "x-forwarded-for": "154.123.178.211",
+        "x-forwarded-proto": "http",
+        "x-forwarded-port": "80",
+        "via": "1.1 vegur",
+        "connect-time": "0",
+        "x-request-start": "1507032897482",
+        "total-route-time": "0",
+        "content-length": "377"
+    },
+    "user": {
+        "name": "Jim",
+        "username": "jim@email.com",
+        "email": "jim@email.com",
+        "createdAt": "2017-09-21T08:21:28.007Z",
+        "updatedAt": "2017-10-03T12:09:01.551Z",
+        "fcm_token": "d84vsHomaz4:APA91bGc_CJnUItY8mDARvF2CLjn7FOxPU16bB0uZr7DLoZ1pgw3T8NVC3b7dDI945lrZ2OgoLs6_cwUDfCWV1lgILFKchPhggn6dEV89z67c5-Qicn3Nx7Xcb95wdqKJ4X3t8wLdkoi",
+        "ACL": {
+            "*": {
+                "read": "true"
+            },
+            "QiR90vrhcR": {
+                "read": "true",
+                "write": "true"
+            }
+        },
+        "sessionToken": "r:bc62398c1da0ad288f55b025c51e5aeb",
+        "objectId": "QiR90vrhcR"
+    },
+    "installationId": "7b96b0e1-fa59-4899-a942-825a69fbea28"
+}
 
     def test_post_webhook_parse(self):
         url = reverse('stories:parse')
-        response = self.client.post(url, self.parse_story)
-        self.assertEqual(response.status_code. status.HTTP_201_CREATED)
+        response = self.client.post(url, data=self.parse_story, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/stories/tests.py
+++ b/stories/tests.py
@@ -74,7 +74,7 @@ class StoryTestAPI(APITestCase):
 
     def test_create_story(self):
         url = reverse('stories:create')
-        print url
+        print(url)
         response = self.client.post(url, self.story_data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -160,3 +160,15 @@ class UserStoriesTest(APITestCase):
         self.assertEqual(len(response.data), 0)
 
 
+class ParseStoryTest(APITestCase):
+    """This tests tests that the Parse Webhook uploads a story to
+    the API after saving the Story in Parse.
+    """
+
+    def setup(self):
+        self.parse_story = {}
+
+    def test_post_webhook_parse(self):
+        url = reverse('stories:parse')
+        response = self.client.post(url, self.parse_story)
+        self.assertEqual(response.status_code. status.HTTP_201_CREATED)

--- a/stories/urls.py
+++ b/stories/urls.py
@@ -8,6 +8,8 @@ from stories import views
 urlpatterns = [
     url(r'^$', views.StoryCreateView.as_view(),
         name="create"),
+    url(r'^parse/$', views.ParseStoryCreateView.as_view(),
+        name="parse"),
     url(r'^media/$', views.MediaUploadView.as_view(),
         name="media"),
     url(r'^user/(?P<fb_id>[0-9]+)/$',

--- a/stories/views.py
+++ b/stories/views.py
@@ -25,12 +25,13 @@ class UserStoriesView(ListAPIView):
         return Story.objects.filter(fb_id=fb_id)
 
 
-# class StoryCreateView(ListCreateAPIView):
-#     queryset = Story.objects.all()
-#     serializer_class = StorySerializer
-class StoryCreateView(APIView):
+class StoryCreateView(ListCreateAPIView):
+    queryset = Story.objects.all()
+    serializer_class = StorySerializer
+    
+class ParseStoryCreateView(APIView):
     def post(self, request, format=None):
-        
+      
         data = request.data["object"]
         data["when"] = data["when"]["iso"]
         data["local_id"] = data["localID"]

--- a/stories/views.py
+++ b/stories/views.py
@@ -4,10 +4,12 @@ from __future__ import unicode_literals
 from rest_framework.generics import (CreateAPIView, ListCreateAPIView,
                                      ListAPIView,
                                      RetrieveUpdateDestroyAPIView)
-
+from rest_framework.views import APIView
+from rest_framework import status
+from rest_framework.response import Response
 from stories.models import Media, Story
 from stories.serializers import (MediaSerializer, StorySerializer,
-                                 UserStoriesSerializer)
+                                 UserStoriesSerializer, ParseStorySerializer)
 
 
 class UserStoriesView(ListAPIView):
@@ -23,9 +25,29 @@ class UserStoriesView(ListAPIView):
         return Story.objects.filter(fb_id=fb_id)
 
 
-class StoryCreateView(ListCreateAPIView):
-    queryset = Story.objects.all()
-    serializer_class = StorySerializer
+# class StoryCreateView(ListCreateAPIView):
+#     queryset = Story.objects.all()
+#     serializer_class = StorySerializer
+class StoryCreateView(APIView):
+    def post(self, request, format=None):
+        
+        data = request.data["object"]
+        data["when"] = data["when"]["iso"]
+        data["local_id"] = data["localID"]
+        data["assignmentId"] = data["assignment"]
+        data["where"] = data["location"]
+        data["updated"] = data["updatedAt"]
+        data["created"] = data["createdAt"]
+        del data["localID"], data["assignment"], 
+        data["className"], data["location"], data["updatedAt"], data["createdAt"]
+        serializer = ParseStorySerializer(data=data)
+        
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        # serializer = ParseStorySerializer(data=req)
 
 
 class StoriesDetailView(RetrieveUpdateDestroyAPIView):

--- a/stories/views.py
+++ b/stories/views.py
@@ -39,7 +39,9 @@ class ParseStoryCreateView(APIView):
         data["where"] = data["location"]
         data["updated"] = data["updatedAt"]
         data["created"] = data["createdAt"]
-        del data["localID"], data["assignment"], 
+        data["local_media_paths"] = [f["url"] for f in data["media"]]
+        
+        del data["localID"], data["assignment"], data["media"],
         data["className"], data["location"], data["updatedAt"], data["createdAt"]
         serializer = ParseStorySerializer(data=data)
         


### PR DESCRIPTION
**What does this PR do?**

This PR enables new stories to be uploaded to the Citizen-Rep api via Parse

**Description of Task to be completed?**

The task was to enable the posting of stories on the Citizen-Reporter API after being saved to Parse.

**How should this be manually tested?**

Create a Story in the Citizen-Reporter app and upload it. 
There should be a new story posted to the API endpoint `/api/stories/` with a `201` status code.
